### PR TITLE
sepolicy: Add perfprofd with set_prop macro

### DIFF
--- a/sepolicy/qcom/perfprofd.te
+++ b/sepolicy/qcom/perfprofd.te
@@ -1,0 +1,5 @@
+# perfprofd disables mpdecision temporarily via setprop ctl.stop,
+# then re-enables afterwards with setprop ctl.start
+userdebug_or_eng(`
+  set_prop(perfprofd, mpdecision_prop)
+')


### PR DESCRIPTION
Addresses:
avc: denied { write }
for pid=293 comm="perfprofd" name="property_service" dev="tmpfs" ino=9229 scontext=u:r:perfprofd:s0 tcontext=u:object_r:property_socket:s0 tclass=sock_file permissive=0

Change-Id: I5a88722eda4d0751fd9a081c434d385ac1c785ef
