### PR TITLE
apns: T-Mobile 310260: Compatibility update

### DIFF
--- a/prebuilt/common/etc/apns-conf.xml
+++ b/prebuilt/common/etc/apns-conf.xml
@@ -1471,9 +1471,9 @@
   <apn carrier="WCW Internet" mcc="310" mnc="180" apn="internet.wcc.net" user="3257630000" password="mmsc" type="default,supl" authtype="0" />
   <apn carrier="WCW-MMS" mcc="310" mnc="180" apn="mms.wcc.net" proxy="209.55.70.246" port="80" mmsc="http://mms.wcc.net" mmsproxy="209.55.70.246" mmsport="80" user="13257630000" password="mmsc" type="mms" authtype="3" />
   <apn carrier="WCW-MMS only" mcc="310" mnc="180" apn="mms.wcc.net" proxy="209.55.70.244" port="80" mmsc="http://mms.wcc.net" mmsproxy="209.55.70.246" mmsport="80" user="3257630000" password="mmsc" type="default,mms" authtype="3" />
-  <apn carrier="T-Mobile US LTE" mcc="310" mnc="260" apn="" type="ia" protocol="IPV4V6" mtu="1440" />
-  <apn carrier="T-Mobile US LTE" mcc="310" mnc="260" apn="fast.t-mobile.com" type="default,supl" protocol="IPV6" roaming_protocol="IP" mtu="1440" />
-  <apn carrier="T-Mobile MMS" mcc="310" mnc="260" apn="TMUS" mmsc="http://mms.msg.eng.t-mobile.com/mms/wapenc" type="mms" protocol="IPV6" roaming_protocol="IP" />
+  <apn carrier="T-Mobile US LTE" mcc="310" mnc="260" apn="fast.t-mobile.com" type="ia" protocol="IPV4V6" mtu="1440" />
+  <apn carrier="T-Mobile US LTE" mcc="310" mnc="260" apn="fast.t-mobile.com" type="default,supl" protocol="IPV4V6" roaming_protocol="IP" mtu="1440" />
+  <apn carrier="T-Mobile MMS" mcc="310" mnc="260" apn="TMUS" mmsc="http://mms.msg.eng.t-mobile.com/mms/wapenc" type="mms" protocol="IPV4V6" roaming_protocol="IP" />
   <apn carrier="Project Fi - T" mcc="310" mnc="260" apn="h2g2" type="ia" protocol="IPV4V6" roaming_protocol="IPV4V6" mvno_match_data="31026097" mvno_type="IMSI" />
   <apn carrier="Project Fi - T" mcc="310" mnc="260" apn="h2g2" user="none" server="*" password="none" mmsc="http://mmsc1.g-mms.com/mms/wapenc" protocol="IPV6" roaming_protocol="IP" mvno_match_data="31026097" mvno_type="IMSI" />
   <apn carrier="T-Mobile IMS" mcc="310" mnc="260" apn="ims" type="ims" protocol="IPV6" />


### PR DESCRIPTION
- Allow both IPv4 and IPv6 protocols for data and mms
- Provide an apn name for the initial attach profile

With respect to initial attach, it seems at least the qcom ril blobs
on my device require the apn field to be set. The following error is
produced and data will not connect on boot unless radio resets (e.g.
airplane mode toggle) so that the default APN is used.

E RILQ    : (0/231): RIL[0][cmd-111(680)] qcril_data_request_set_lte_attach_profile: ril_apn (provided NULL) is mandatory param for looking up profile.
E RILQ    : (0/231): RIL[0][cmd-111(680)] qcril_data_request_set_lte_attach_profile: EXIT with FAILURE
E RILQ    : (0/231): RIL[0][cmd-111(680)] qcril_qmi_nas_set_initial_attach_apn: Data RIL call for Attach APN failed with Error code 2

Change-Id: Ie983474780a7443c870911994234ea2f2025de12
